### PR TITLE
Use dedicated logger in event fixer

### DIFF
--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -93,10 +93,11 @@ def fix(event):
         global fixup_error_loggings
         fixup_error_loggings += 1
         is_power_of_two = lambda n: not (n & (n - 1))
+        logger = logging.getLogger("caldav")
         if is_power_of_two(fixup_error_loggings):
-            log = logging.warning
+            log = logger.warning
         else:
-            log = logging.debug
+            log = logger.debug
 
         log_message = [
             "Ical data was modified to avoid compatibility issues",


### PR DESCRIPTION
This change makes the event fixer use the "caldav" logger used otherwise througout the project instead of global logging.

This will allow for complete muting of the warning messages when an event is automatically adjusted.
It's probably easier than forcing e.g. Apple to be standards compliant.

https://github.com/python-caldav/caldav/issues/426#issuecomment-2397075495
https://github.com/home-assistant/core/issues/111633